### PR TITLE
Allow for preloading the suffixes file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Or install it yourself as:
     url.subdomain # => "foo.bar"
     url.path      # => "/asdf.html?q=arg"
 
+    # optionally preload suffixes file to avoid loading on each call to `#parse`
+    Rippersnapper.load_suffixes
+    # subsequent calls to parse will use the same `SuffixFileReader` instance
+
+    # unloading the suffixes simply sets the internal variable to `nil`
+    Rippersnapper.unload_suffixes
+
 ## Notable differences between Rippersnapper and [Domainatrix](https://github.com/pauldix/domainatrix)
 
 One of Rippersnappers goals is to be a compatible API with Domainatrix, but

--- a/lib/rippersnapper.rb
+++ b/lib/rippersnapper.rb
@@ -8,4 +8,26 @@ module Rippersnapper
   def self.parse url
     Url.new url
   end
+
+  # Load public suffix file into class instance var to be reused
+  #
+  # @return [void]
+  def self.load_suffixes file = nil
+    @suffix_file_reader = SuffixFileReader.new(file)
+  end
+
+  # Accessor for loaded suffix reader
+  #
+  # @return [SuffixFileReader]
+  # @return [nil] if not loaded
+  def self.suffix_file_reader
+    @suffix_file_reader
+  end
+
+  # Unload public suffix file
+  #
+  # @return [void]
+  def self.unload_suffixes
+    @suffix_file_reader = nil
+  end
 end

--- a/lib/rippersnapper/domain_parser.rb
+++ b/lib/rippersnapper/domain_parser.rb
@@ -60,7 +60,8 @@ module Rippersnapper
     end
 
     def suffix_reader
-      @suffix_reader ||= SuffixFileReader.new
+      @suffix_reader ||= (Rippersnapper.suffix_file_reader ||
+                          SuffixFileReader.new)
     end
   end
 end

--- a/spec/rippersnapper/domain_parser_spec.rb
+++ b/spec/rippersnapper/domain_parser_spec.rb
@@ -61,5 +61,18 @@ module Rippersnapper
       end
     end
 
+    context "preloaded suffix file" do
+      before { Rippersnapper.load_suffixes }
+      after { Rippersnapper.unload_suffixes }
+
+      subject { described_class.new("").send(:suffix_reader) }
+
+      it { is_expected.to be_kind_of SuffixFileReader }
+
+      it "uses the preloaded reader" do
+        expect(subject.object_id)
+          .to eq(Rippersnapper.suffix_file_reader.object_id)
+      end
+    end
   end
 end

--- a/spec/rippersnapper_spec.rb
+++ b/spec/rippersnapper_spec.rb
@@ -3,4 +3,32 @@ describe Rippersnapper do
     subject { Rippersnapper.parse "www.google.com" }
     it { is_expected.to be_a_kind_of Rippersnapper::Url }
   end
+
+  describe "::load_suffixes" do
+    subject { described_class.load_suffixes }
+    after { described_class.unload_suffixes }
+    it { is_expected.to be_a_kind_of described_class::SuffixFileReader }
+  end
+
+  describe "::suffix_file_reader" do
+    subject { described_class.suffix_file_reader }
+    it { is_expected.to be_nil }
+
+    context "with loaded suffixes" do
+      before { described_class.load_suffixes }
+      after { described_class.unload_suffixes }
+      it { is_expected.to be_a_kind_of described_class::SuffixFileReader }
+    end
+  end
+
+  describe "::unload_suffixes" do
+    before { described_class.load_suffixes }
+    after { described_class.unload_suffixes }
+
+    it "unloads suffixes" do
+      expect(described_class.suffix_file_reader).to_not be_nil
+      described_class.unload_suffixes
+      expect(described_class.suffix_file_reader).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Currently, every call to `Rippersnapper::parse` results in the suffix file being loaded. It's a large(ish) file and causes a fair amount of object allocation for a file that typically doesn't change often for an
application.

This updates the top-level `Rippersnapper` module to have three new methods:
- `::load_suffixes` - creates a new instance of `Rippersnapper::SuffixFileReader` with an optional file path and assigns it to a class instance variable.
- `::unload_suffixes` - resets the class instance variable to `nil` to preserve the current behavior of loading the file each time.
- `::suffix_file_reader` - simple accessor to get to the class ivar.

Internally, `Rippersnapper::DomainParser` checks for the existence of `Rippersnapper::suffix_file_reader` and uses that. If the module-level reader isn't found it defaults to the original behavior of loading a new
instance and reading the file.

Corresponding specs have been updated and make liberal use of the `::unload_suffixes` method to make sure existing tests don't use the preloaded file.
## 

I tried to make as few changes as possible to get the behavior I needed. I could see a few ways to make this work and this one was the least intrusive to the existing API. Please let me know if there's something about this PR that could be better or an alternative you'd like to see.

Thanks!
